### PR TITLE
feat: satellite reorder for all frameworks and nesting levels (#14)

### DIFF
--- a/Inspector.pde
+++ b/Inspector.pde
@@ -3,6 +3,9 @@
 int   selectedNode = -1;
 float inspectorCX, inspectorCY;
 
+// Reselect after swap: set to the moved node; cleared in draw() once found
+NodeState pendingSelectNode = null;
+
 float[][] hitTargets;
 int       hitCount;
 
@@ -230,6 +233,19 @@ void drawSidebar() {
   } else { fill(MUTED);noStroke();textSize(11);textAlign(LEFT,TOP); text("(select hub)",x+SB_PAD,y); y+=18; }
   y+=4; sbDivider(y); y+=12;
 
+  // Reorder (any satellite with siblings, all frames)
+  if (isSatellite) {
+    int numSib = (selectedOwner != null) ? selectedOwner.numSatellites()
+                 : (activeStates() != null ? activeStates().length - 1 : 0);
+    if (numSib >= 2) {
+      y = sbSectionLabel("Reorder", x, y);
+      float bw2 = (SB_W - SB_PAD*2 - 4) / 2.0;
+      sbButton("\u25c4", x+SB_PAD,        y, bw2, 26, "SWAP_PREV", false);
+      sbButton("\u25ba", x+SB_PAD+bw2+4,  y, bw2, 26, "SWAP_NEXT", false);
+      y += 34; sbDivider(y); y += 12;
+    }
+  }
+
   // Nesting (nested tab only)
   if (isNested) {
     y=sbSectionLabel("Nesting",x,y);
@@ -398,6 +414,8 @@ void sbHandleClick(String tag,float mx,float my){
   else if(tag.equals("SWITCH_CROSS"))    ns.subType=SLOT_CROSS;
   else if(tag.equals("SWITCH_SPOKE"))    ns.subType=SLOT_SPOKE;
   else if(tag.equals("DELETE_NODE"))     deleteSatellite();
+  else if(tag.equals("SWAP_PREV"))       swapSatellite(-1);
+  else if(tag.equals("SWAP_NEXT"))       swapSatellite(+1);
 }
 
 void deleteSatellite(){
@@ -411,6 +429,56 @@ void deleteSatellite(){
     setActiveStates(next);
   }
   selectedNode=-1;
+}
+
+// ── Satellite reordering ──────────────────────────────────────────────────────
+// direction < 0 = swap with previous slot (wraps), direction > 0 = swap with next slot (wraps)
+// Hub nodes carry their entire sub-diagram because we swap NodeState references.
+void swapSatellite(int direction) {
+  selectedNodeState(); // refresh selectedOwner and selectedLocalIdx
+  if (selectedLocalIdx <= 0) return;
+
+  NodeState movedNode;
+
+  if (selectedOwner != null) {
+    // Satellite inside a hub's children[] (nested, or Frame-2 outer ring)
+    int n = selectedOwner.numSatellites();
+    if (n <= 1) return;
+    int cur  = selectedLocalIdx;
+    int next = (direction < 0) ? (cur == 1 ? n : cur-1)
+                                : (cur == n ? 1 : cur+1);
+    NodeState tmp = selectedOwner.children[cur];
+    selectedOwner.children[cur]  = selectedOwner.children[next];
+    selectedOwner.children[next] = tmp;
+    selectedOwner.recomputeAngles();
+    movedNode = selectedOwner.children[next];
+  } else {
+    // Top-level satellite in Frame 0 or 1
+    NodeState[] states = activeStates();
+    if (states == null) return;
+    int n = states.length - 1;
+    if (n <= 1) return;
+    int cur  = selectedLocalIdx;
+    int next = (direction < 0) ? (cur == 1 ? n : cur-1)
+                                : (cur == n ? 1 : cur+1);
+    NodeState tmp = states[cur];
+    states[cur]  = states[next];
+    states[next] = tmp;
+    recomputeTopLevelAngles(states);
+    movedNode = states[next];
+  }
+
+  pendingSelectNode = movedNode;
+}
+
+// Recalculate fixed angles for top-level spoke (frame 0) or cross (frame 1) arrays.
+void recomputeTopLevelAngles(NodeState[] states) {
+  int n = states.length - 1;
+  for (int i = 0; i < n; i++) {
+    states[i+1].ang = (activeFrame == 0)
+      ? radians(180 + i * (360.0/n))
+      : radians(i * (360.0/n));
+  }
 }
 
 void setActiveStates(NodeState[]next){

--- a/Shapes.pde
+++ b/Shapes.pde
@@ -28,6 +28,15 @@ void draw(){
   if(activeFrame>=0){
     resetHitTargets(512);
     pushMatrix(); translate(inspectorCX,inspectorCY); drawFramework(activeFrame); popMatrix();
+    // After a swap, reselect the moved node by matching its NodeState reference
+    if (pendingSelectNode != null) {
+      for (int i = 0; i < hitCount; i++) {
+        if (resolveHit((int)hitTargets[i][3]) == pendingSelectNode) {
+          selectedNode = i; break;
+        }
+      }
+      pendingSelectNode = null;
+    }
     drawSelectionRing();
   } else drawEmptyState();
   drawHUD();


### PR DESCRIPTION
## Summary

- Adds a compact **Reorder** section to the sidebar with `◄` and `►` buttons that appear whenever a satellite with at least one sibling is selected
- Clicking `◄` / `►` swaps the satellite with its previous / next neighbour (wraps around), covering the full rotate-clockwise / anti-clockwise use case via repeated presses
- Hub nodes carry their entire sub-diagram on swap (all satellites, nested hubs, images, labels, scales) because only the `NodeState` reference is moved in the array — no data is copied or reconstructed
- Selection ring follows the moved node automatically via a `pendingSelectNode` reference resolved on the next draw frame
- Works across all three frameworks: **n-spoke radial**, **n-node cross**, and **nested level** (both outer ring and any depth of nesting)

## Test plan

### Frame 0 — n-spoke radial
- [ ] Open n-spoke with 4+ spokes. Select any satellite. Confirm **Reorder** section appears with `◄` `►` buttons.
- [ ] Click `►` repeatedly — satellite steps clockwise one slot per click; all other nodes stay put; spacing remains equal.
- [ ] Click `◄` repeatedly — satellite steps counter-clockwise; wraps from first slot back to last slot.
- [ ] Verify the selection ring (blue outline) follows the moved satellite each time.
- [ ] Confirm the moved node retains its label, colour, shape, alpha, and any image after swapping.
- [ ] With only 1 satellite present, confirm the **Reorder** section does **not** appear.

### Frame 1 — n-node cross
- [ ] Same steps as Frame 0 on the cross layout. Confirm bidirectional arrows redraw correctly at the new positions.

### Frame 2 — nested level, outer ring
- [ ] Promote the framework hub to a spoke/cross with 3+ satellites. Select one. Confirm Reorder buttons appear.
- [ ] Swap — verify equal spacing is maintained and no visual artefacts.

### Frame 2 — nested level, hub-satellite swap
- [ ] Promote satellite B to a spoke with 4 sub-satellites (one of which is itself a 3-cross). Select satellite A (plain circle) and satellite B (spoke hub) as separate test subjects.
- [ ] Swap B past A using `◄` / `►` — B should move to A's old slot **with all its sub-satellites intact**; A should appear at B's old slot.
- [ ] Confirm B's sub-diagram scale (`subOrbitR`, `subScale`) is unchanged after the swap.
- [ ] Confirm A's radius is unchanged after the swap.

### Frame 2 — deeply nested satellites
- [ ] Create a hub → satellite → promote that satellite to a hub → add 3 sub-satellites. Select one sub-satellite and confirm Reorder appears.
- [ ] Swap and verify equal spacing and correct selection follow at the nested level.

### Wrap-around
- [ ] With 3 satellites A, B, C, select A (first slot) and press `◄` — A should wrap to the last slot (where C was), resulting in B, C, A.
- [ ] Select C (now last slot) and press `►` — C should wrap to the first slot.

### Persistence
- [ ] Perform several swaps, then **Save state**. Reload via **Load state**. Confirm the reordered positions are preserved correctly.

### No crowding regression
- [ ] With the framework hub (index 0) selected, confirm **Reorder** does **not** appear.
- [ ] With a node that has no siblings (only child), confirm **Reorder** does **not** appear.