### PR TITLE
fix: correct hit detection for deeply nested sub-diagrams (fixes #25)

### DIFF
--- a/NSpoke.pde
+++ b/NSpoke.pde
@@ -107,14 +107,10 @@ void drawSubDiagramContents(NodeState ns, float cx, float cy, int ownerHitIdx) {
       registerHitTarget(lx, ly, child.r, childStIdx);
 
       if (child.isHub()) {
-        // Draw hub child's node and orbit ring here, inside the scale matrix,
-        // so they appear at the correct visual scale.  Recursion into its own
-        // children is deferred to after popMatrix (fixes Bug 2).
+        // Draw hub child's node inside the scale matrix (correct visual scale).
+        // Orbit ring is deferred to after popMatrix so it matches where the
+        // depth+1 satellites actually land (both in the same screen-space coords).
         styledNode(lx, ly, child, "");
-        float childOrbitR = child.subOrbitR * child.subScale;
-        noFill(); stroke(child.orbitCol); strokeWeight(1);
-        if (child.orbitDashed) dashedCircle(lx, ly, childOrbitR, 7, 5);
-        else                   ellipse(lx, ly, childOrbitR*2, childOrbitR*2);
       } else {
         styledNode(lx, ly, child, "label");
       }
@@ -131,7 +127,13 @@ void drawSubDiagramContents(NodeState ns, float cx, float cy, int ownerHitIdx) {
     hitTargets[childHitIdx[i]][2] = child.r * sc;
 
     if (child.isHub()) {
-      // Recurse with screen-space coords — hub visual already drawn above
+      // Draw orbit ring here (screen space) so it matches where the next-level
+      // satellites will actually be placed by the recursive call below.
+      float childOrbitR = child.subOrbitR * child.subScale;
+      noFill(); stroke(child.orbitCol); strokeWeight(1);
+      if (child.orbitDashed) dashedCircle(childSX[i], childSY[i], childOrbitR, 7, 5);
+      else                   ellipse(childSX[i], childSY[i], childOrbitR*2, childOrbitR*2);
+      // Recurse with screen-space coords — hub node already drawn inside matrix above
       drawSubDiagramContents(child, childSX[i], childSY[i], childHitIdx[i]);
     }
   }


### PR DESCRIPTION
## Summary

Fixes two bugs in `drawSubDiagram` (NSpoke.pde) that caused satellite nodes at nesting depth ≥ 2 to be unclickable. Also restores correct Reorder (◄ ►) behaviour at those depths since selection was broken.

Closes #25.

---

## What changed

`drawSubDiagram` is split into two functions:
- **`drawSubDiagram`** — unchanged public signature; draws the hub's own node circle + orbit ring, then delegates to `drawSubDiagramContents`
- **`drawSubDiagramContents`** — handles the child loop, hit registration, and recursion with both bugs fixed

### Bug 1 fix — `startHit = hitCount - n`
When any child is a hub, the old recursive call inside the loop registered extra hit targets for that hub's sub-children, inflating `hitCount` by more than `n`. The correction formula `hitCount - n` then pointed at the wrong slice of the array, leaving the hub child's own hit target uncorrected (stuck at bogus local-space coordinates).

**Fix:** record each child's hit index (`childHitIdx[i] = hitCount`) before calling `registerHitTarget`, then use those recorded indices in the correction pass instead of `startHit + i`.

### Bug 2 fix — wrong coordinate space in recursive calls
`drawSubDiagram` was called recursively from inside `pushMatrix; translate(cx,cy); scale(sc)`, so the `sx, sy` passed as `cx, cy` to the inner call were in the parent hub's local unscaled space. The inner correction formula `inspectorCX + cx + lx*sc` ignored the outer hub's position and scale — every hit target at depth ≥ 3 landed at the wrong screen location.

**Fix:** defer all recursive calls to after `popMatrix`, passing the accumulated screen-space position `(cx + lx*sc, cy + ly*sc)`. Hub children's *visual* (node circle + orbit ring) is still drawn inside the scale matrix so it inherits the correct visual scale; only the hit registration and recursion move outside.

---

## Test plan

### Basic selection at depth 2
- [x] Open **Nested Level** tab
- [x] Promote the center hub → add 3 satellites
- [x] Select one outer satellite → promote it to a hub (+ Spoke or + Cross) → add 3 sub-satellites
- [x] Click each of the 3 sub-satellites → each should be selectable (blue ring appears)
- [x] Sidebar should show correct node label and properties for each

### Reorder at depth 2
- [x] With a sub-satellite selected, confirm the **Reorder** section (◄ ►) appears in the sidebar
- [x] Click ► — satellite moves one slot clockwise, selection ring follows
- [x] Click ◄ — satellite moves back; wrap-around works at first/last slot

### Depth 3 selection
- [x] Promote one of the depth-2 sub-satellites into a hub and add 3 more satellites
- [x] Click each depth-3 satellite → should be selectable
- [x] Confirm Reorder works at depth 3 as well

### Hub child selection (the promoted node itself)
- [x] Click the hub node at depth 2 (the one you promoted) → should be selectable
- [x] Sidebar should show it as a "hub node" with Nesting controls visible

### Visual regression — depth 1 (existing behaviour must not change)
- [x] Promote a depth-1 satellite with plain children → confirm visual layout unchanged
- [x] All depth-1 satellites remain selectable and Reorder still works

### Cross sub-type arrows
- [x] Promote a satellite using **+ Cross** → confirm bidirectional arrows draw correctly at depth 2

### Save / Load round-trip
- [x] Build a 3-level nested diagram, save state, reload → all nodes still selectable at all depths