### PR TITLE
fix: set fill alpha to 0 when image is uploaded to a node

### DIFF
--- a/NodeState.pde
+++ b/NodeState.pde
@@ -152,7 +152,7 @@ NodeState pendingImportNode = null;
 void imageSelected(File f) {
   if (f==null||pendingImageNode==null) return;
   PImage loaded=loadImage(f.getAbsolutePath());
-  if (loaded!=null) { pendingImageNode.img=loaded; pendingImageNode.invalidateCache(); }
+  if (loaded!=null) { pendingImageNode.img=loaded; pendingImageNode.alpha=0; pendingImageNode.invalidateCache(); }
   pendingImageNode=null;
 }
 


### PR DESCRIPTION
## Summary
- On image upload, `alpha` is automatically set to 0 so the fill circle no longer hides the image
- User can restore fill at any time via the Alpha slider or color swatches

Closes #20

## Test plan
- [ ] Select any node → Add img → image is immediately visible (no opaque fill on top)
- [ ] Drag Alpha slider up → fill reappears over image as expected
- [ ] Save and reload state → alpha=0 persists for image nodes