### PR TITLE
fix: image now fills diamond crop correctly

### DIFF
--- a/NodeState.pde
+++ b/NodeState.pde
@@ -111,12 +111,9 @@ class NodeState {
     if (imgCacheSize==diameter&&imgCacheShape==shapeType&&imgMasked!=null) return;
     imgCacheSize=diameter; imgCacheShape=shapeType;
 
-    int imgSize = (shapeType==SHAPE_DIAMOND) ? (int)(diameter/sqrt(2.0)) : diameter;
-    int offset  = (diameter-imgSize)/2;
-
     PGraphics imgG=createGraphics(diameter,diameter,JAVA2D);
     imgG.beginDraw(); imgG.clear();
-    imgG.image(img, offset, offset, imgSize, imgSize);
+    imgG.image(img, 0, 0, diameter, diameter);
     imgG.endDraw();
 
     PGraphics mask=createGraphics(diameter,diameter,JAVA2D);


### PR DESCRIPTION
## Summary
- Removed incorrect `diameter/sqrt(2)` scaling for diamond crop — image now fills the full canvas and the diamond mask clips it cleanly
- No change to circle or rect crop behaviour

Closes #21

## Test plan
- [ ] Upload image to a node → Crop to shape → Diamond → image fills all 4 vertices, no transparent gaps
- [ ] Switch to Circle and Rect → crop still works correctly
- [ ] Resize node with `[`/`]` → crop stays aligned