### PR TITLE
feat: add no-fill and default swatches to color picker

### DIFF
--- a/Inspector.pde
+++ b/Inspector.pde
@@ -193,7 +193,7 @@ void drawSidebar() {
   // Node appearance
   y = sbSectionLabel("Node", x, y);
   y = sbColorRow("Fill", ns.fillCol, ns.alpha, true, "NODE_COLOR", x, y);
-  y = sbAlphaSlider("Alpha (overlay)", ns.alpha, "NODE_ALPHA", x, y);
+  y = sbAlphaSlider("Fill alpha", ns.alpha, "NODE_ALPHA", x, y);
   y = sbShapeRow(ns.shapeType, x, y);
   y+=4; sbDivider(y); y+=12;
 

--- a/Shapes.pde
+++ b/Shapes.pde
@@ -134,7 +134,7 @@ void styledNode(float x,float y,NodeState ns,String sub){
     else{float asp=(float)ns.img.width/ns.img.height;
       float imgH=diameter/sqrt(asp*asp+1),imgW=imgH*asp;
       imageMode(CENTER);image(ns.img,x,y,imgW,imgH);imageMode(CORNER);}}
-  color fc=color(red(ns.fillCol),green(ns.fillCol),blue(ns.fillCol),hasImg?ns.alpha:255);
+  color fc=color(red(ns.fillCol),green(ns.fillCol),blue(ns.fillCol),ns.alpha);
   fill(fc);noStroke();drawShape(x,y,ns);
   noFill();stroke(BORDER);strokeWeight(1.5);drawShape(x,y,ns);
   fill(FG);noStroke();


### PR DESCRIPTION
## Summary
- No-fill swatch (slash icon): sets alpha=0, fill becomes transparent for any node (image or plain)
- Default swatch (color 245): restores node to its original appearance, matching unedited nodes
- Clicking any color swatch now restores alpha=255 automatically
- Orbit color row gains default + colour swatches
- Fill alpha now applies to all nodes, not just image nodes (was hardcoded to 255 for plain nodes)
- Alpha slider relabelled from "Alpha (overlay)" to "Fill alpha"

Closes #28

## Test plan
- [ ] Select a plain node (no image) → click slash swatch → fill disappears, only border visible
- [ ] Click default swatch → node looks identical to neighbouring unedited nodes
- [ ] Click red/grey/green swatch → colour applied and alpha restores to 255
- [ ] Upload image to a node → slash swatch makes fill transparent, image shows through
- [ ] Save and reload → alpha=0 persists correctly