### PR TITLE
feat: View mode collapse/expand hub nodes with auto-zoom (#44)

### DIFF
--- a/NSpoke.pde
+++ b/NSpoke.pde
@@ -54,6 +54,7 @@ void drawNodesWithState(int n, NodeState[] states, float orbitR,
 // used to rotate the satellite cluster so it faces away from the centre.
 void drawSubDiagram(NodeState ns, float cx, float cy, int ownerHitIdx, float hubAngle) {
   styledNode(cx, cy, ns);
+  if (appMode==1 && ns.viewCollapsed) { drawViewHubTint(cx, cy, ns); return; }
   float screenOrbitR = ns.subOrbitR * ns.subScale;
   noFill(); stroke(ns.orbitCol); strokeWeight(1);
   if (ns.orbitDashed) dashedCircle(cx, cy, screenOrbitR, 7, 5);
@@ -101,11 +102,8 @@ void drawSubDiagramContents(NodeState ns, float cx, float cy, int ownerHitIdx, f
       childHitIdx[i] = hitCount;
       registerHitTarget(lx, ly, child.r, childStIdx);
 
-      if (child.isHub()) {
-        styledNode(lx, ly, child);
-      } else {
-        styledNode(lx, ly, child);
-      }
+      styledNode(lx, ly, child);
+      if (child.isHub() && appMode==1 && child.viewCollapsed) drawViewHubTint(lx, ly, child);
     }
   popMatrix();
 
@@ -115,7 +113,7 @@ void drawSubDiagramContents(NodeState ns, float cx, float cy, int ownerHitIdx, f
     hitTargets[childHitIdx[i]][1] = inspectorCY + childSY[i];
     hitTargets[childHitIdx[i]][2] = child.r * sc;
 
-    if (child.isHub()) {
+    if (child.isHub() && !(appMode==1 && child.viewCollapsed)) {
       float childOrbitR = child.subOrbitR * child.subScale;
       noFill(); stroke(child.orbitCol); strokeWeight(1);
       if (child.orbitDashed) dashedCircle(childSX[i], childSY[i], childOrbitR, 7, 5);

--- a/NodeState.pde
+++ b/NodeState.pde
@@ -18,6 +18,7 @@ class NodeState {
   String  subLabel      = "";          // optional sub-label shown below main label
   color   orbitCol    = color(180);
   boolean orbitDashed = true;
+  boolean viewCollapsed = false;  // transient View-mode state; never serialized
 
   PImage  img           = null;
   boolean cropToShape   = true;

--- a/Shapes.pde
+++ b/Shapes.pde
@@ -39,9 +39,18 @@ void draw(){
     drawHUD();
     sbResetZones(); drawSidebar();
   } else {
+    float ch=height-canvasY-20;
+    float canvasR=min(width,ch)*0.45;
+    float ext=viewExtent(twoState!=null&&twoState.length>0?twoState[0]:null);
+    float vs=(ext>0)?canvasR/ext:1.0;
     inspectorCX=width/2.0;
-    inspectorCY=canvasY+(height-20-canvasY)/2.0;
-    pushMatrix(); translate(inspectorCX,inspectorCY); drawFramework(activeFrame); popMatrix();
+    inspectorCY=canvasY+ch/2.0;
+    resetHitTargets(512);
+    pushMatrix(); translate(inspectorCX,inspectorCY); scale(vs); drawFramework(activeFrame); popMatrix();
+    // Correct hit targets from diagram-space to screen-space with viewScale applied
+    for(int i=0;i<hitCount;i++){
+      float wx=hitTargets[i][0]-inspectorCX, wy=hitTargets[i][1]-inspectorCY;
+      hitTargets[i][0]=inspectorCX+wx*vs; hitTargets[i][1]=inspectorCY+wy*vs; hitTargets[i][2]*=vs;}
   }
   drawToast();
 }
@@ -61,12 +70,18 @@ void mousePressed(){
   for(int i=0;i<numButtons;i++){
     float x=btnGap+i*(btnW+btnGap),y=btnTop;
     if(mouseX>x&&mouseX<x+btnW&&mouseY>y&&mouseY<y+btnH){
+      if(i==0&&appMode!=0)resetViewCollapsed();
+      if(i==1&&appMode!=1)collapseAllForView();
       appMode=i;return;}}
   if(appMode==0){
     if(editingLabel)commitLabelEdit(selectedNodeState());
     if(editingSubLabel)commitSubLabelEdit(selectedNodeState());
     if(editingFilename)commitFilenameEdit();
-    selectedNode=pickNode(mouseX,mouseY);}}
+    selectedNode=pickNode(mouseX,mouseY);
+  } else {
+    int hit=pickNode(mouseX,mouseY);
+    if(hit>=0){NodeState ns=resolveHit((int)hitTargets[hit][3]);
+      if(ns!=null&&ns.isHub())ns.viewCollapsed=!ns.viewCollapsed;}}}
 
 void mouseDragged(){if(appMode==0&&mouseX>=sbX())sbMouseDragged(mouseX,mouseY);}
 void mouseReleased(){if(appMode==0)sbMouseReleased();}
@@ -117,6 +132,30 @@ void drawButtons(){
     fill(active?color(230,242,255):color(245));stroke(active?color(80,140,210):BORDER);strokeWeight(active?1.8:0.8);
     rect(x,y,btnW,btnH,10);
     fill(active?color(30,80,160):FG);noStroke();textSize(13);textAlign(CENTER,CENTER);text(modeLabels[i],x+btnW/2,y+btnH/2);}}
+
+void resetViewCollapsed(){resetViewCollapsedRec(twoState);}
+void resetViewCollapsedRec(NodeState[]arr){
+  if(arr==null)return;
+  for(NodeState ns:arr){ns.viewCollapsed=false;if(ns.isHub())resetViewCollapsedRec(ns.children);}}
+
+void collapseAllForView(){collapseAllRec(twoState);}
+void collapseAllRec(NodeState[]arr){
+  if(arr==null)return;
+  for(NodeState ns:arr){if(ns.isHub()){ns.viewCollapsed=true;collapseAllRec(ns.children);}}}
+
+// Max screen-space radius from a node's centre given current viewCollapsed state
+float viewExtent(NodeState ns){
+  if(ns==null)return 0;
+  if(!ns.isHub()||ns.viewCollapsed)return ns.r;
+  float orbitR=ns.subOrbitR*ns.subScale, maxExt=ns.r;
+  for(int i=1;i<ns.children.length;i++){
+    NodeState c=ns.children[i];
+    maxExt=max(maxExt,orbitR+(c.isHub()&&!c.viewCollapsed?viewExtent(c):c.r*ns.subScale));}
+  return maxExt;}
+
+// Blue tint overlay drawn on top of styledNode for any hub in View mode
+void drawViewHubTint(float cx,float cy,NodeState ns){
+  fill(color(80,140,210,50));noStroke();drawShape(cx,cy,ns);}
 
 void drawEmptyState(){fill(MUTED);noStroke();textSize(13);textAlign(CENTER,CENTER);
   text("Nothing to display",(width-SB_W)/2.0,canvasY+(height-canvasY)/2.0);}

--- a/TwoLevel.pde
+++ b/TwoLevel.pde
@@ -22,6 +22,13 @@ void drawTwoLevel(int nInner, int nOuter) {
   int hubHitIdx = hitCount;
   registerHitTarget(0, 0, hub.r, 0);
 
+  // In View mode, collapsed top hub: draw hub + tint only
+  if (appMode==1 && hub.viewCollapsed) {
+    styledNode(0, 0, hub);
+    drawViewHubTint(0, 0, hub);
+    return;
+  }
+
   float screenOrbitR = hub.subOrbitR * hub.subScale;
   styledOrbit(0, 0, screenOrbitR, hub);
 
@@ -45,8 +52,14 @@ void drawTwoLevel(int nInner, int nOuter) {
     int childHitIdx = hitCount;
     registerHitTarget(sx, sy, child.r * hub.subScale, childStIdx);
 
-    if (child.isHub()) drawSubDiagram(child, sx, sy, childHitIdx, child.ang);
-    else               styledNode(sx, sy, child);
+    if (child.isHub() && appMode==1 && child.viewCollapsed) {
+      styledNode(sx, sy, child);
+      drawViewHubTint(sx, sy, child);
+    } else if (child.isHub()) {
+      drawSubDiagram(child, sx, sy, childHitIdx, child.ang);
+    } else {
+      styledNode(sx, sy, child);
+    }
   }
 
   // Draw hub circle on top (already registered — just draw)


### PR DESCRIPTION
## Summary
- `viewCollapsed` boolean added to `NodeState` (transient, never serialized)
- Entering View mode collapses all hubs recursively — starts at the most collapsed state
- Clicking a blue-tinted hub expands it; clicking an expanded hub re-collapses it
- Blue tint overlay only shows on hubs that are still collapsed (hidden children); expanded hubs render normally
- Auto-zoom: `viewExtent()` recursively computes the bounding radius of the current expansion state and scales the diagram to fill 90% of the canvas; hit targets are corrected post-draw so clicks remain accurate
- All collapse state resets when switching back to Edit mode

Closes #44
Part of #40

## Test plan
- [ ] Entering View collapses to a single large hub circle
- [ ] Blue tint visible only on collapsed hubs
- [ ] Clicking a collapsed hub expands it; diagram rescales to fit
- [ ] Clicking an expanded hub collapses it again
- [ ] No NodeState data changes after any toggle
- [ ] Switching to Edit restores full diagram and clears all collapse state