### PR TITLE
fix: correct sub-label distance and alignment on image nodes (#38)

### DIFF
--- a/DrawUtils.pde
+++ b/DrawUtils.pde
@@ -20,16 +20,22 @@ void styledNode(float x, float y, NodeState ns) {
   noFill(); stroke(BORDER); strokeWeight(1.5); drawShape(x, y, ns);
   fill(FG); noStroke();
   if (hasImg) {
-    float lx = x + (ns.r+10)*sin(ns.labelAng), ly = y - (ns.r+10)*cos(ns.labelAng);
+    boolean hasSub = !ns.subLabel.isEmpty();
+    int subSize = max(9, ns.labelSize-2);
+    // TODO(#38): at diagonal angles the text block can still clip the node boundary;
+    // dist only accounts for the radial direction, not the full text-block footprint.
+    // Fix: project the label bounding box onto the outward normal and pad accordingly.
+    float dist = ns.r + ns.labelSize*0.5 + 4;
+    float lx = x + dist*sin(ns.labelAng), ly = y - dist*cos(ns.labelAng);
     float nx = sin(ns.labelAng), ny = -cos(ns.labelAng);
-    int ha, va;
-    if (abs(nx) >= abs(ny)) { ha = nx>0 ? LEFT : RIGHT; va = CENTER; }
-    else                    { ha = CENTER; va = ny<0 ? BOTTOM : TOP; }
-    textSize(ns.labelSize); textAlign(ha, va); text(ns.label, lx, ly);
-    if (!ns.subLabel.isEmpty()) {
-      fill(MUTED); textSize(max(9, ns.labelSize-2));
-      float subLy = (va==BOTTOM) ? ly-(ns.labelSize+2) : (va==TOP) ? ly+(ns.labelSize+2) : ly+ns.labelSize/2+2;
-      textAlign(ha, TOP); text(ns.subLabel, lx, subLy);
+    int ha = (abs(nx) >= abs(ny)) ? (nx>0 ? LEFT : RIGHT) : CENTER;
+    float totalH = hasSub ? ns.labelSize + subSize + 3 : ns.labelSize;
+    float topY = ly - totalH/2.0;
+    textSize(ns.labelSize); textAlign(ha, TOP); text(ns.label, lx, topY);
+    if (hasSub) {
+      fill(MUTED); textSize(subSize);
+      float leftX = (ha==LEFT) ? lx : (ha==RIGHT) ? lx - textWidth(ns.label) : lx - textWidth(ns.label)/2.0;
+      textAlign(LEFT, TOP); text(ns.subLabel, leftX, topY + ns.labelSize + 3);
     }
   } else {
     textSize(ns.labelSize); textAlign(CENTER, CENTER);

--- a/DrawUtils.pde
+++ b/DrawUtils.pde
@@ -22,19 +22,17 @@ void styledNode(float x, float y, NodeState ns) {
   if (hasImg) {
     boolean hasSub = !ns.subLabel.isEmpty();
     int subSize = max(9, ns.labelSize-2);
-    // TODO(#38): at diagonal angles the text block can still clip the node boundary;
-    // dist only accounts for the radial direction, not the full text-block footprint.
-    // Fix: project the label bounding box onto the outward normal and pad accordingly.
-    float dist = ns.r + ns.labelSize*0.5 + 4;
+    float totalH = hasSub ? ns.labelSize + subSize + 3 : ns.labelSize;
+    float dist = ns.r + totalH/2.0 + 4;
     float lx = x + dist*sin(ns.labelAng), ly = y - dist*cos(ns.labelAng);
     float nx = sin(ns.labelAng), ny = -cos(ns.labelAng);
     int ha = (abs(nx) >= abs(ny)) ? (nx>0 ? LEFT : RIGHT) : CENTER;
-    float totalH = hasSub ? ns.labelSize + subSize + 3 : ns.labelSize;
     float topY = ly - totalH/2.0;
     textSize(ns.labelSize); textAlign(ha, TOP); text(ns.label, lx, topY);
     if (hasSub) {
+      float mainLabelW = textWidth(ns.label);
       fill(MUTED); textSize(subSize);
-      float leftX = (ha==LEFT) ? lx : (ha==RIGHT) ? lx - textWidth(ns.label) : lx - textWidth(ns.label)/2.0;
+      float leftX = (ha==LEFT) ? lx : (ha==RIGHT) ? lx - mainLabelW : lx - mainLabelW/2.0;
       textAlign(LEFT, TOP); text(ns.subLabel, leftX, topY + ns.labelSize + 3);
     }
   } else {


### PR DESCRIPTION
## Summary
- Uses `totalH/2` (full text-block height) instead of `labelSize/2` to compute `dist`, preventing the sub-label from clipping inside the node circle at any label angle
- Captures `mainLabelW = textWidth(ns.label)` before switching to `subSize`, fixing the left-edge calculation for CENTER/RIGHT alignment so both labels are flush-left

Fixes #38

## Test plan
- [ ] Add a sub-label to an image node and rotate the label angle through all positions — sub-label should stay outside the circle boundary at all angles
- [ ] Verify "Domain: Programming"-style labels have flush left alignment between main label and sub-label